### PR TITLE
Track requests/responses to CH

### DIFF
--- a/server/src/api/routes/mcp.ts
+++ b/server/src/api/routes/mcp.ts
@@ -164,7 +164,18 @@ server.registerTool("get_visitor_count_for_date", {
     }
   }
 })
+server.registerTool('get_recent_responses', {
+  title: 'Get recent responses from Companies House to requests on the Streaming API',
+  description: 'Returns the last 20 responses from Companies House to requests on the Streaming API. Useful for debugging during outages. If the user wants to know when the last response (success or failure) was for a stream, call this tool and choose the relevant stream to show the user.',
+  inputSchema: z.object({}),
+}, async()=>{
+  const responseMessages = await redisClient.xRevRange("ch:responses", '+', '-', {COUNT: 20})
+  const responses = responseMessages.map(r=>r.message).map(({ headersObject, ...message }) => ({...message, ...(headersObject ? {headers: JSON.parse(headersObject)} : {}) }))
 
+  return {
+    content: [{ type: "text", text: JSON.stringify({ responses }) }]
+  }
+})
 await server.connect(transport)
 
 export const mcpRouter = (app: Elysia) => {

--- a/server/src/api/routes/misc.ts
+++ b/server/src/api/routes/misc.ts
@@ -19,4 +19,8 @@ export const miscRouter = (app: Elysia) => {
       const schemas = Object.fromEntries(Object.entries(schemasRaw).map(([schemaName, schemaString]) => [schemaName, JSON.parse(schemaString)]))
       return schemas
     })
+    .get('/responses', async () => {
+      const responseMessages = await redisClient.xRevRange("ch:responses", '+', '-', {COUNT: 20})
+      return responseMessages.map(r=>r.message)
+    })
 }

--- a/server/src/api/routes/misc.ts
+++ b/server/src/api/routes/misc.ts
@@ -21,6 +21,7 @@ export const miscRouter = (app: Elysia) => {
     })
     .get('/responses', async () => {
       const responseMessages = await redisClient.xRevRange("ch:responses", '+', '-', {COUNT: 20})
-      return responseMessages.map(r=>r.message)
+      const responses = responseMessages.map(r=>r.message)
+      return responses.map(({ headersObject, ...message }) => ({...message, ...(headersObject ? {headers: JSON.parse(headersObject)} : {}) }))
     })
 }

--- a/server/src/chStreamToRedis/streamToRedis.ts
+++ b/server/src/chStreamToRedis/streamToRedis.ts
@@ -31,7 +31,7 @@ const incrEventCount = (streamPath: string) => (event: AnyEvent) => redisClient.
 const incrResourceKindCount = (streamPath: string) => (event: AnyEvent) => redisClient.hIncrBy(`resourceKinds:${streamPath}`, event.resource_kind, 1)
 const updateTimepoint = (streamPath: string) => (event: AnyEvent) => redisClient.set("timepoints:" + streamPath, JSON.stringify(event.event), { EX: 86400 * 7 })
 const heartbeat = (streamPath: string) => () => redisClient.hSet("heartbeats", streamPath, Date.now()) // keeps track of which are alive
-const getMostRecentTimepoint = (streamPath: string) => redisClient.get("timepoints:" + streamPath).then(r => r ? JSON.parse(r)?.timepoint : undefined)
+const getMostRecentTimepoint = (streamPath: string) => redisClient.get("timepoints:" + streamPath).then(r => r ? JSON.parse(r)?.timepoint + 1 : undefined)
 const startStream = (streamPath: string): Promise<Readable> => getMostRecentTimepoint(streamPath)
   .then((timepoint) => stream(streamPath, timepoint)
     .on("data", sendEvent(streamPath))

--- a/server/src/streams/listenOnStream.ts
+++ b/server/src/streams/listenOnStream.ts
@@ -4,9 +4,8 @@ import { streamKeyHolder } from "../utils/KeyHolder.js"
 import pino from "pino"
 import { CustomJsonParse } from "./jsonParseStream.js"
 import { Readable } from "node:stream"
-import { AnyEvent } from "../types/eventTypes"
 import { redisClient } from "../utils/getRedisClient"
-import { String } from "@sinclair/typebox"
+import { type } from "node:os"
 
 export type StreamPath =
   | "insolvency-cases"
@@ -17,7 +16,7 @@ export type StreamPath =
   | "officers"
   | "disqualified-officers"
   | string
-
+const BASE_URL = 'stream.companieshouse.gov.uk'
 interface ResponseLogEventBase extends Record<string, string> {
 correlationId: string,
   type: 'response_started'|'response_ended'
@@ -31,6 +30,7 @@ interface ResponseStartedLogEvent extends ResponseLogEventBase {
   headersObject:string,
   requestedTimepoint: string,
   ttfb_ms: string
+  base_url: string
 }
 interface ResponseEndedLogEvent extends ResponseLogEventBase {
   type: 'response_ended',
@@ -55,7 +55,7 @@ export function stream<EventType>(streamPath: StreamPath, startFromTimepoint?: n
   const timepointQueryString = typeof startFromTimepoint === "number" ? `?timepoint=${startFromTimepoint}` : ""
   const path = "/" + streamPath + timepointQueryString
   const options: RequestOptions = {
-    hostname: "stream.companieshouse.gov.uk", port: 443, path, auth: streamKey + ":"
+    hostname: BASE_URL, port: 443, path, auth: streamKey + ":"
   }
   const parser = new CustomJsonParse({}, true)
   const handleError = (message: string) => (e: Error) => {
@@ -78,6 +78,7 @@ export function stream<EventType>(streamPath: StreamPath, startFromTimepoint?: n
       status: statusCode?.toString() ?? '',
       ttfb_ms: ttfbMs.toString(),
       urlPath: path,
+      base_url: 'https://'+BASE_URL,
       stream: streamPath, type: 'response_started', correlationId, timestamp: new Date().toISOString(), requestedTimepoint: startFromTimepoint?.toString()??'' })
     switch (res.statusCode) {
       case 429:

--- a/server/src/streams/listenOnStream.ts
+++ b/server/src/streams/listenOnStream.ts
@@ -5,7 +5,7 @@ import pino from "pino"
 import { CustomJsonParse } from "./jsonParseStream.js"
 import { Readable } from "node:stream"
 import { redisClient } from "../utils/getRedisClient"
-import { type } from "node:os"
+
 
 export type StreamPath =
   | "insolvency-cases"
@@ -29,8 +29,8 @@ interface ResponseStartedLogEvent extends ResponseLogEventBase {
   status: string,
   headersObject:string,
   requestedTimepoint: string,
-  ttfb_ms: string
-  base_url: string
+  ttfbMs: string
+  baseUrl: string
 }
 interface ResponseEndedLogEvent extends ResponseLogEventBase {
   type: 'response_ended',
@@ -76,9 +76,9 @@ export function stream<EventType>(streamPath: StreamPath, startFromTimepoint?: n
     logResponse({
       headersObject: JSON.stringify(res.headers),
       status: statusCode?.toString() ?? '',
-      ttfb_ms: ttfbMs.toString(),
+      ttfbMs: ttfbMs.toString(),
       urlPath: path,
-      base_url: 'https://'+BASE_URL,
+      baseUrl: 'https://'+BASE_URL,
       stream: streamPath, type: 'response_started', correlationId, timestamp: new Date().toISOString(), requestedTimepoint: startFromTimepoint?.toString()??'' })
     switch (res.statusCode) {
       case 429:

--- a/server/src/streams/listenOnStream.ts
+++ b/server/src/streams/listenOnStream.ts
@@ -4,6 +4,9 @@ import { streamKeyHolder } from "../utils/KeyHolder.js"
 import pino from "pino"
 import { CustomJsonParse } from "./jsonParseStream.js"
 import { Readable } from "node:stream"
+import { AnyEvent } from "../types/eventTypes"
+import { redisClient } from "../utils/getRedisClient"
+import { String } from "@sinclair/typebox"
 
 export type StreamPath =
   | "insolvency-cases"
@@ -15,11 +18,39 @@ export type StreamPath =
   | "disqualified-officers"
   | string
 
+interface ResponseLogEventBase extends Record<string, string> {
+correlationId: string,
+  type: 'response_started'|'response_ended'
+  timestamp: string,
+  stream: StreamPath
+}
+interface ResponseStartedLogEvent extends ResponseLogEventBase {
+  type: 'response_started'
+  urlPath: string,
+  status: string,
+  headersObject:string,
+  requestedTimepoint: string,
+  ttfb_ms: string
+}
+interface ResponseEndedLogEvent extends ResponseLogEventBase {
+  type: 'response_ended',
+}
+type ResponseLogEvent = ResponseStartedLogEvent | ResponseEndedLogEvent
+
+const logResponse = (event: ResponseLogEvent) => redisClient.xAdd("ch:responses", "*", event, {
+  TRIM: {
+    strategy: "MAXLEN",
+    threshold: 1000,
+    strategyModifier: "~"
+  }
+})
+
 /**
  * Returns a readable stream of events. The recommended way of listening to a stream in this application.
  */
 export function stream<EventType>(streamPath: StreamPath, startFromTimepoint?: number): Readable {
-  const logger = pino({ base: { streamPath } })
+  const correlationId = crypto.randomUUID()
+  const logger = pino({ base: { streamPath, correlationId } })
   const streamKey = streamKeyHolder.useKey()
   const timepointQueryString = typeof startFromTimepoint === "number" ? `?timepoint=${startFromTimepoint}` : ""
   const path = "/" + streamPath + timepointQueryString
@@ -37,9 +68,17 @@ export function stream<EventType>(streamPath: StreamPath, startFromTimepoint?: n
   }
   parser.on("error", handleError("Error on parser stream"))
   logger.info({ path }, "Requesting to connect to stream")
+  const requestTime = Date.now()
   request(options, (res) => {
+    const ttfbMs = Date.now() - requestTime
     const { statusMessage, statusCode } = res
     logger.info({ path, res: { statusMessage, statusCode } }, "Response received from stream")
+    logResponse({
+      headersObject: JSON.stringify(res.headers),
+      status: statusCode?.toString() ?? '',
+      ttfb_ms: ttfbMs.toString(),
+      urlPath: path,
+      stream: streamPath, type: 'response_started', correlationId, timestamp: new Date().toISOString(), requestedTimepoint: startFromTimepoint?.toString()??'' })
     switch (res.statusCode) {
       case 429:
         logger.fatal("Exiting due to hitting rate limit")
@@ -57,7 +96,15 @@ export function stream<EventType>(streamPath: StreamPath, startFromTimepoint?: n
         handleError("Non 200 status code response received")
         break
     }
-    res.on("end", handleError("Stream ended. 'end' event triggered"))
+    res.on("end", (err:any) => {
+      logResponse({
+        type: 'response_ended',
+        correlationId,
+        timestamp: new Date().toISOString(),
+        stream: streamPath
+      });
+      handleError("Stream ended. 'end' event triggered")(err);
+    })
       .on("error", handleError("error on response stream"))
   })
     .on("error", handleError("Error on request"))


### PR DESCRIPTION
Store requests made and responses received to/from Companies House streaming API.

This could be useful, eg to see when the last successful response was, or when the stream disconnected, or when the last error was received.

Analytics could calculate the proportion of responses that are errors over a time period to measure service reliability.